### PR TITLE
Add max connections support

### DIFF
--- a/josh-mongo/README.md
+++ b/josh-mongo/README.md
@@ -60,6 +60,7 @@ Here is a list of full options this provider supports:
 | [providerOptions.port] | <code>string</code> | Optional, defaults to `27017`. The port where mongodb is hosted. |
 | [providerOptions.host] | <code>string</code> | Optional, defaults to `localhost`. The host/machine/URL where the mongodb connection is located. Should never be an HTTP address! |
 | [providerOptions.url] | <code>string</code> | Optional, single-line configuration. If used, ignores all other options except `options.collection`, and requires the full connection string to access the database, *including the database name* |
+| [providerOptions.maxConnections] | <code>number</code> | Optional. The maximum amount of connections Josh may concurrently make to your database. *Setting a very low value may prevent Josh from writing to your database at all.* |
 
 ## Mongo Atlas Configuration
 

--- a/josh-mongo/src/index.js
+++ b/josh-mongo/src/index.js
@@ -22,6 +22,7 @@ class JoshProvider {
     this.dbName = options.dbName || 'josh';
     this.port = options.port || 27017;
     this.host = options.host || 'localhost';
+    this.maxConnections = options.maxConnections || undefined;
     this.url =
       options.url ||
       `mongodb://${this.auth}${this.host}:${this.port}/${this.dbName}`;
@@ -36,6 +37,7 @@ class JoshProvider {
     this.client = await MongoClient.connect(this.url, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
+      maxPoolSize: this.maxConnections,
     }).catch((err) => console.error(err));
     this.db = this.client.db(this.dbName).collection(this.collection);
     return this.client.isConnected();


### PR DESCRIPTION
It would be quite helpful, especially for datasets hosted on MongoDB Atlas and similar services that limit connections, to be able to set the maximum amount of connections Josh can concurrently use. This pull request adds that feature, and allows users to provide `maxConnections` in the provider options object to set it.