### PR TITLE
feat(JSONProvider): add `useAbsolutePath` option

### DIFF
--- a/packages/json/src/lib/ChunkHandler.ts
+++ b/packages/json/src/lib/ChunkHandler.ts
@@ -21,11 +21,11 @@ export class ChunkHandler<StoredValue = unknown> {
   public files: Record<string, ChunkFile<StoredValue>> = {};
 
   public constructor(options: ChunkHandlerOptions) {
-    const { name, version, dataDirectoryName, epoch, retry } = options;
+    const { name, version, useAbsolutePath, dataDirectory, epoch, retry } = options;
 
     this.options = options;
     this.snowflake = epoch === undefined ? TwitterSnowflake : new Snowflake(epoch);
-    this.directory = resolve(process.cwd(), dataDirectoryName ?? 'data', name);
+    this.directory = useAbsolutePath ? resolve(dataDirectory ?? 'data', name) : resolve(process.cwd(), dataDirectory ?? 'data', name);
     this.index = new ChunkIndexFile({ version, directory: this.directory, retry });
   }
 
@@ -361,7 +361,9 @@ export interface ChunkHandlerOptions {
 
   version: JoshProvider.Semver;
 
-  dataDirectoryName?: string;
+  useAbsolutePath?: boolean;
+
+  dataDirectory?: string;
 
   maxChunkSize: number;
 

--- a/packages/json/tests/lib/ChunkHandler.test.ts
+++ b/packages/json/tests/lib/ChunkHandler.test.ts
@@ -16,7 +16,7 @@ describe('ChunkHandler', () => {
       name: 'chunkHandler',
       version: { major: 0, minor: 0, patch: 0 },
       maxChunkSize: 100,
-      dataDirectoryName: '.tests',
+      dataDirectory: '.tests',
       serialize: false
     });
 

--- a/packages/json/tests/lib/JSONProvider.test.ts
+++ b/packages/json/tests/lib/JSONProvider.test.ts
@@ -7,5 +7,5 @@ mkdirSync(resolve(process.cwd(), '.tests', 'provider'), { recursive: true });
 
 runProviderTest<typeof JSONProvider, JSONProvider.Options>({
   providerConstructor: JSONProvider,
-  providerOptions: { dataDirectoryName: '.tests', disableSerialization: true }
+  providerOptions: { dataDirectory: '.tests', disableSerialization: true }
 });


### PR DESCRIPTION
Resolves #94 

<details><summary>

### Commit Body

</summary>

BREAKING CHANGE: `JSONProvider.Options#dataDirectoryName` has been renamed to `dataDirectory`

</details>

