### PR TITLE
fix(deps): update dependency @joshdb/provider

### DIFF
--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -40,7 +40,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -27,7 +27,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "@sapphire/async-queue": "^1.5.0",
     "@sapphire/snowflake": "^3.2.2",
@@ -40,6 +40,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -26,7 +26,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "@sapphire/utilities": "^3.11.0",
     "property-helpers": "^2.0.0"
@@ -37,6 +37,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -37,7 +37,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/maria/package.json
+++ b/packages/maria/package.json
@@ -37,7 +37,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/maria/package.json
+++ b/packages/maria/package.json
@@ -26,7 +26,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "@sapphire/snowflake": "^3.2.2",
     "mariadb": "^3.0.2"
@@ -37,6 +37,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -39,7 +39,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -27,7 +27,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "@sapphire/utilities": "^3.11.0",
     "mongodb": "~4.11.0",
@@ -39,6 +39,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -41,7 +41,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -28,7 +28,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "@sapphire/snowflake": "^3.2.2",
     "@sapphire/utilities": "^3.11.0",
@@ -41,6 +41,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -24,7 +24,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "redis": "^4.4.0",
     "uuid": "^9.0.0"
@@ -36,6 +36,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -36,7 +36,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -38,7 +38,6 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
-    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -26,7 +26,7 @@
     "check-update": "cliff-jumper --dry-run"
   },
   "dependencies": {
-    "@joshdb/provider": "2.0.0-next.f40a41e.0",
+    "@joshdb/provider": "2.0.0-next.24b745c.0",
     "@joshdb/serialize": "1.1.0-next.24b745c.0",
     "@sapphire/utilities": "^3.11.0",
     "better-sqlite3": "^7.6.2",
@@ -38,6 +38,7 @@
     "@vitest/coverage-c8": "^0.25.0",
     "typedoc": "^0.23.20",
     "typedoc-json-parser": "^7.0.1",
+    "typescript": "^4.8.4",
     "vitest": "^0.25.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,7 +1234,7 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@sapphire/async-queue": ^1.5.0
     "@sapphire/snowflake": ^3.2.2
@@ -1243,6 +1243,7 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1253,13 +1254,14 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@sapphire/utilities": ^3.11.0
     "@vitest/coverage-c8": ^0.25.0
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1270,13 +1272,14 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@sapphire/snowflake": ^3.2.2
     "@vitest/coverage-c8": ^0.25.0
     mariadb: ^3.0.2
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1287,7 +1290,7 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@sapphire/utilities": ^3.11.0
     "@vitest/coverage-c8": ^0.25.0
@@ -1295,6 +1298,7 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1305,7 +1309,7 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@sapphire/snowflake": ^3.2.2
     "@sapphire/utilities": ^3.11.0
@@ -1314,9 +1318,20 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
+
+"@joshdb/provider@npm:2.0.0-next.24b745c.0":
+  version: 2.0.0-next.24b745c.0
+  resolution: "@joshdb/provider@npm:2.0.0-next.24b745c.0"
+  dependencies:
+    "@sapphire/utilities": ^3.11.0
+    reflect-metadata: ^0.1.13
+  checksum: ccc33f7f4d0b4c42a67553198fb42ae48753fcf96b45cac4adadd0e0b0ac3471d0448c2c410733dd7684f51036e59263046e31b9f80c7f65d7fdc65cdc42f099
+  languageName: node
+  linkType: hard
 
 "@joshdb/provider@npm:2.0.0-next.f40a41e.0":
   version: 2.0.0-next.f40a41e.0
@@ -1334,13 +1349,14 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@types/uuid": ^8.3.4
     "@vitest/coverage-c8": ^0.25.0
     redis: ^4.4.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     uuid: ^9.0.0
     vitest: ^0.25.0
   languageName: unknown
@@ -1359,7 +1375,7 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/rollup-type-bundler": ^1.0.11
-    "@joshdb/provider": 2.0.0-next.f40a41e.0
+    "@joshdb/provider": 2.0.0-next.24b745c.0
     "@joshdb/serialize": 1.1.0-next.24b745c.0
     "@sapphire/utilities": ^3.11.0
     "@vitest/coverage-c8": ^0.25.0
@@ -1367,6 +1383,7 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
+    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,7 +1243,6 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1261,7 +1260,6 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1279,7 +1277,6 @@ __metadata:
     mariadb: ^3.0.2
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1298,7 +1295,6 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1318,7 +1314,6 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft
@@ -1356,7 +1351,6 @@ __metadata:
     redis: ^4.4.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     uuid: ^9.0.0
     vitest: ^0.25.0
   languageName: unknown
@@ -1383,7 +1377,6 @@ __metadata:
     property-helpers: ^2.0.0
     typedoc: ^0.23.20
     typedoc-json-parser: ^7.0.1
-    typescript: ^4.8.4
     vitest: ^0.25.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Why add typescript?

It's requested by typedoc, this silences the output of yarn:
```sh
@joshdb/sqlite@workspace:packages/sqlite doesn't provide typescript (p9f420), requested by typedoc
```